### PR TITLE
feat(domains): support multiply domains (#14)

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -8,7 +8,7 @@ export default {
   },
   layouts: {},
   i18n: {
-    locales: ['en', 'pl', 'de'],
+    locales: ['en'],
     defaultLocale: 'en',
     onLocaleChange: () => null,
     beforeLocaleChange: () => null

--- a/lib/templates/lib/domains.js
+++ b/lib/templates/lib/domains.js
@@ -1,0 +1,34 @@
+import { SET_DOMAIN, SET_LOCALES } from '~typo3/store/mutation-types'
+import { getHostByURL } from '~typo3/lib/route'
+
+/**
+ * Find domain based on host and available domain list
+ *
+ * @param {Object} context - Nuxt context
+ * @returns {Object} domain - Active domain object
+ */
+function getDomain({ app, req }) {
+  // get host depends on environment - SSR or browser
+  if (app.$typo3.options.domains && app.$typo3.options.domains.length) {
+    const host = getHostByURL(req ? req.headers.host : window.location.origin)
+    return app.$typo3.options.domains.find(domain => domain.name === host)
+  }
+  return false
+}
+
+/**
+ * Set active domain to store
+ *
+ * @param {Object} Context - Nuxt context
+ * @param {Object} domain - Active domain object
+ * @returns {void}
+ */
+function setDomain({ store, app }, domain) {
+  if (domain) {
+    app.$typo3.api.setOptions(domain.api)
+    store.commit(SET_LOCALES, domain.i18n.locales)
+    store.commit(SET_DOMAIN, domain)
+  }
+}
+
+export { getDomain, setDomain }

--- a/lib/templates/lib/route.js
+++ b/lib/templates/lib/route.js
@@ -8,4 +8,24 @@ function isDynamicRoute(route) {
   return route.matched[0].path.includes('*')
 }
 
-export { isDynamicRoute }
+/**
+ * Get domain host from url
+ * e.g. https://en.myservice.com:4000/path returns en.myservice.com
+ *
+ * @param {String} url
+ */
+function getHostByURL(url) {
+  const match = url.match(/^(http:\/\/|https:\/\/)?(www[0-9]?.)?([^/:]*).*$/)
+  if (
+    match != null &&
+    match.length > 2 &&
+    typeof match[3] === 'string' &&
+    match[3].length > 0
+  ) {
+    return match[3]
+  } else {
+    return null
+  }
+}
+
+export { isDynamicRoute, getHostByURL }

--- a/lib/templates/plugins/api.js
+++ b/lib/templates/plugins/api.js
@@ -1,8 +1,18 @@
 import API from '~typo3/lib/api'
 import { getLocaleCodePath } from '~typo3/lib/i18n'
 export default function(context, options) {
+  const { store, $axios } = context
   const api = {
-    ...new API(options, context.$axios)
+    ...new API(
+      store.state.typo3 && store.state.typo3.domain
+        ? store.state.typo3.domain
+        : options,
+      $axios
+    ),
+    setOptions(options) {
+      Object.assign(this.$http.defaults, options)
+      Object.assign(this.options, options)
+    }
   }
 
   // add initialData fallback for 404 pages

--- a/lib/templates/plugins/context.js
+++ b/lib/templates/plugins/context.js
@@ -1,10 +1,12 @@
 import api from '~typo3/plugins/api'
 import i18n from '~typo3/plugins/i18n'
+import domains from '~typo3/plugins/domains'
 export default function (context, inject) {
   const moduleOptions = <%= serialize(options) %>
   const _options = {
     api: api(context, moduleOptions),
     i18n: i18n(context, moduleOptions),
+    domains: domains(context, moduleOptions),
     options: moduleOptions
   }
   inject('typo3', _options)

--- a/lib/templates/plugins/domains.js
+++ b/lib/templates/plugins/domains.js
@@ -1,0 +1,8 @@
+import { getDomain, setDomain } from '~typo3/lib/domains'
+export default (context, options) => {
+  return {
+    list: options.domains ? options.domains : [],
+    getDomain: () => getDomain(context),
+    setDomain: domain => setDomain(context, domain)
+  }
+}

--- a/lib/templates/plugins/i18n.js
+++ b/lib/templates/plugins/i18n.js
@@ -3,9 +3,16 @@ import { getLocaleCodePath, getLocaleByPath, setLocale } from '~typo3/lib/i18n'
 export default (context, options) => {
   return {
     ...options.i18n,
-    locale: context.store.state.typo3
-      ? context.store.state.typo3.locale
-      : options.i18n.defaultLocale,
+    get locale() {
+      return context.store.state.typo3
+        ? context.store.state.typo3.locale
+        : options.i18n.defaultLocale
+    },
+    get locales() {
+      return context.store.state.typo3 && context.store.state.typo3.locales
+        ? context.store.state.typo3.locales
+        : options.i18n.locales
+    },
     getLocaleCodePath: () => getLocaleCodePath(context),
     getLocaleByPath: () => getLocaleByPath(context),
     setLocale: (localeCode, updateInitialData) =>

--- a/lib/templates/store/actions.js
+++ b/lib/templates/store/actions.js
@@ -5,6 +5,9 @@ export default {
    * Called during SSR init
    */
   async nuxtServerInit({ commit, dispatch, state }, { app }) {
+    if (app.$typo3.domains) {
+      app.$typo3.domains.setDomain(app.$typo3.domains.getDomain())
+    }
     app.$typo3.i18n.setLocale(app.$typo3.i18n.getLocaleByPath(), false)
     await dispatch('getInitialData')
   },

--- a/lib/templates/store/index.js
+++ b/lib/templates/store/index.js
@@ -10,7 +10,9 @@ export default ({ store }) => {
       layout: 'default',
       locale: '',
       initial: {},
-      page: {}
+      page: {},
+      domain: null,
+      locales: null
     },
     actions,
     mutations

--- a/lib/templates/store/mutation-types.js
+++ b/lib/templates/store/mutation-types.js
@@ -1,3 +1,5 @@
 export const SET_INITIAL = 'SET_INITIAL_DATA'
 export const SET_LOCALE = 'SET_LOCALE_ACTIVE'
+export const SET_LOCALES = 'SET_AVAILABLE_LOCALES'
 export const SET_PAGE = 'SET_PAGE_DATA'
+export const SET_DOMAIN = 'SET_DOMAIN'

--- a/lib/templates/store/mutations.js
+++ b/lib/templates/store/mutations.js
@@ -8,5 +8,11 @@ export default {
   },
   [types.SET_PAGE](state, data) {
     state.page = data
+  },
+  [types.SET_DOMAIN](state, domain) {
+    state.domain = domain
+  },
+  [types.SET_LOCALES](state, locales) {
+    state.locales = locales
   }
 }


### PR DESCRIPTION
fixes #14. 

Now you are able to setup different domains in nuxt-typo3 options 

```js
     ...
    "domains": [{
        "name": "website.com",
        "baseURL": "https://website.com",
        "api": {
          "baseURL": "https://api.website.com"
        },
        "i18n": {
          "locales": [
            "en"
          ],
          "defaultLocale": "en"
        }
      },
      {
        "name": "de.website.com",
        "baseURL": "https://de.website.com",
        "api": {
          "baseURL": "https://api.de.website.com"
        },
        "i18n": {
          "locales": [
            "cz", "en"
          ],
          "defaultLocale": "cz"
        }
      },
```