### PR TITLE
feat(options): add runtime config support

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,14 @@ import defu from 'defu'
 import _options from './options'
 
 function Typo3(options) {
+  const { nuxt } = this
+  const runtimeConfig =
+    nuxt.options.publicRuntimeConfig && nuxt.options.publicRuntimeConfig.typo3
   options = defu(this.options.typo3, _options)
+  if (runtimeConfig) {
+    options = defu(runtimeConfig, options)
+  }
+
   // add $typo3pwa context
   this.addPlugin({
     src: resolve(__dirname, './templates/plugins/context.js'),

--- a/lib/templates/plugins/context.js
+++ b/lib/templates/plugins/context.js
@@ -1,8 +1,15 @@
+import defu from 'defu'
 import api from '~typo3/plugins/api'
 import i18n from '~typo3/plugins/i18n'
 import domains from '~typo3/plugins/domains'
 export default function (context, inject) {
-  const moduleOptions = <%= serialize(options) %>
+  const runtimeConfig = context.$config && context.$config.typo3
+  let moduleOptions = <%= serialize(options) %>
+
+  if (runtimeConfig) {
+    moduleOptions = defu(runtimeConfig, moduleOptions)
+  }
+
   const _options = {
     api: api(context, moduleOptions),
     i18n: i18n(context, moduleOptions),


### PR DESCRIPTION
How to use ? 
According to documentation: https://nuxtjs.org/guide/runtime-config/ 

`nuxt.config.js:`
```js
export default {
  publicRuntimeConfig: {
    typo3: {}
  },
}
```
