### PR TITLE
fix: typing error of word 'extension' in docs

### DIFF
--- a/docs/from-scratch/1-backend.md
+++ b/docs/from-scratch/1-backend.md
@@ -1,6 +1,6 @@
 # 1. Provide API
 
-Provide API by installation [TYPO3 headless](https://github.com/TYPO3-Initiatives/headless) extenstion.
+Provide API by installation [TYPO3 headless](https://github.com/TYPO3-Initiatives/headless) extension.
 
 
 Install extension using composer


### PR DESCRIPTION
Just a quick fix of a typing error of the word 'extension' in the documentation