### PR TITLE
fix: Delete redundant default values

### DIFF
--- a/lib/templates/components/content/elements/CeTextpic.vue
+++ b/lib/templates/components/content/elements/CeTextpic.vue
@@ -18,13 +18,11 @@ export default {
   props: {
     gallery: {
       type: Object,
-      required: true,
-      default: () => {}
+      required: true
     },
     bodytext: {
       type: String,
-      required: true,
-      default: ''
+      required: true
     }
   }
 }


### PR DESCRIPTION
 As long as props are required, default values are useless