### PR TITLE
fix: Correct wrong component tag name

### DIFF
--- a/lib/templates/components/content/elements/CeHeader.vue
+++ b/lib/templates/components/content/elements/CeHeader.vue
@@ -5,9 +5,9 @@
       v-if="headerLayout >= 0 && headerLayout !== 100"
       :class="headerPosition"
     >
-      <nav-link v-if="headerLink" :to="headerLink.url">
+      <nuxt-link v-if="headerLink" :to="headerLink.url">
         {{ header }}
-      </nav-link>
+      </nuxt-link>
       <template v-else>{{ header }}</template>
     </component>
     <component :is="`h${headerLevel + 1}`" v-if="subheader">


### PR DESCRIPTION
There is no such a component in a project. It was possibly mistaken with NavLink from ReactRouter