### PR TITLE
fix: check if header is not null

### DIFF
--- a/lib/templates/components/content/elements/CeHeader.vue
+++ b/lib/templates/components/content/elements/CeHeader.vue
@@ -1,5 +1,9 @@
 <template>
-  <div v-if="headerLayout !== 100" :class="headerCss" class="ce-header">
+  <div
+    v-if="header && headerLayout !== 100"
+    :class="headerCss"
+    class="ce-header"
+  >
     <component
       :is="`h${headerLevel}`"
       v-if="headerLayout >= 0 && headerLayout !== 100"


### PR DESCRIPTION
If header is an empty string, component will be rendered with empty html tags.