### PR TITLE
htmlAttrs with lang inside getMeta

### DIFF
--- a/lib/templates/mixins/seo/getMeta.js
+++ b/lib/templates/mixins/seo/getMeta.js
@@ -8,6 +8,9 @@ export default {
           pageData.meta.title ||
           pageData.title ||
           this.$nuxt.$options.head.title,
+        htmlAttrs: {
+          lang: this.$typo3.i18n.locale
+        },
         meta: [
           {
             hid: 'generator',


### PR DESCRIPTION
Added htmlAttrs inside getMeta() to fix HTML validation for lang attribute inside `<html />` tag