### PR TITLE
Check if headerLink.url is not null

### DIFF
--- a/lib/templates/components/content/elements/CeHeader.vue
+++ b/lib/templates/components/content/elements/CeHeader.vue
@@ -9,7 +9,7 @@
       v-if="headerLayout >= 0 && headerLayout !== 100"
       :class="headerPosition"
     >
-      <nav-link v-if="headerLink" :to="headerLink.url">
+      <nav-link v-if="headerLink && headerLink.url" :to="headerLink.url">
         {{ header }}
       </nav-link>
       <template v-else>{{ header }}</template>


### PR DESCRIPTION
headerLink.url is not validated in CeHeader component.

If target page is deleted or hidden, Vue will throw a warning:

`Invalid prop: type check failed for prop "to". Expected String, Object, got Undefined`

And href is empty.