### PR TITLE
fix: add module to build transpile options (#201)

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -104,6 +104,8 @@ function Typo3 (options) {
     // avoid warning about about consola dependency in case of standalone build
     config.plugins.push(new webpack.ContextReplacementPlugin(/consola/))
   })
+
+  this.options.build.transpile.push('nuxt-typo3')
 }
 
 module.exports = Typo3


### PR DESCRIPTION
This adds the module to the build transpile options. 
That is required because the optional chaining operator (`?.`) is used, without this NuxtJS cannot compile the operator and throws and error at build-time.

Fixes: #201