### PR TITLE
feat: add option for disable store (#214)

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -48,11 +48,13 @@ function Typo3 (options) {
   })
 
   // add typo3pwa store
-  this.addPlugin({
-    src: resolve(__dirname, './store/index.js'),
-    options,
-    fileName: join('typo3', 'store.index.js')
-  })
+  if (options.store) {
+    this.addPlugin({
+      src: resolve(__dirname, './store/index.js'),
+      options,
+      fileName: join('typo3', 'store.index.js')
+    })
+  }
 
   // add i18n router middleware
   this.addPlugin({

--- a/lib/options.js
+++ b/lib/options.js
@@ -13,5 +13,6 @@ export default {
   },
   components: true,
   forms: false,
+  store: true,
   debug: false
 }


### PR DESCRIPTION
resolve #214 

It gives the possibility of overriding typo3 store logic. 
`nuxt.config.js`:
```js
  typo3: {
    api: {
      baseURL: 'https://api.t3pwa.com'
    },
    store: false
  },
  plugins: ['~/plugins/store'],
  ```

overriding is possible only with plugin because in nuxt-typo3 we have used nuxtServerInit so we have non-namespaced module (nuxt by default is registering store module as namespaced)

`plugins.store.js`:
```js
import { SET_INITIAL } from '~typo3/store/mutation-types'
import mutations from '~typo3/store/mutations'

import { isDynamicRoute } from '~typo3/lib/route'
const actions = {
  /**
   * Called during SSR init
   */
  async nuxtServerInit ({ dispatch }, { app }) {
    // server init logic
  },
  /**
   * Get initial data during nuxtServerInit
   *
   * @param {ActionContext} [vuexContext] commit
   * @return {void}
   */
  getInitialData (
    { commit },
    params = {
      path: this.$router.currentRoute.params.pathMatch
    }
  ) {
    // initialdata logic
  }
}

export default ({ store }) => {
  store.registerModule('typo3', {
    // can't be namespaced - we have to call nuxtServerInit
    // https://nuxtjs.org/guide/vuex-store/#the-nuxtserverinit-action

    state: {
      layout: 'default',
      locale: '',
      initial: {},
      page: {},
      domain: null,
      locales: null
    },
    actions,
    mutations
  })
}

```