### PR TITLE
fix: wrap figcaption in figure to validate html

### DIFF
--- a/lib/components/T3MediaFile/type/Image.vue
+++ b/lib/components/T3MediaFile/type/Image.vue
@@ -16,10 +16,10 @@
           :alt="props.file.properties.alternative || false"
           :title="props.file.properties.title || ''"
         >
+        <figcaption v-if="props.file.properties.description">
+          {{ props.file.properties.description }}
+        </figcaption>
       </figure>
-      <figcaption v-if="props.file.properties.description">
-        {{ props.file.properties.description }}
-      </figcaption>
     </component>
   </div>
 </template>


### PR DESCRIPTION
<figcaption> usage is only permitted as child of <figure>.